### PR TITLE
Better handling of urlFactory(myBaseUrl)(relativePath) without parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "files": [
     "lib"
   ],
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Set a base url and encode params with minimum fuss. Especially useful with JSON API.",
   "main": "lib/index.js",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -36,5 +36,8 @@ export default (baseUrl = '', baseParams = {}) =>
             return memo
         }, {...params})
 
-        return `${baseUrl}${relativeUrl}${separator}${encodeParams(params)}`
+        const encodedParams = encodeParams(params)
+        return encodedParams && encodedParams.length > 0
+            ? `${baseUrl}${relativeUrl}${separator}${encodedParams}`
+            : `${baseUrl}${relativeUrl}`
     }


### PR DESCRIPTION
If no params are passed for encoding, do not append a ? or & to the provided path.

Paired with @cannoneyed 